### PR TITLE
PCI: endpoint: Update NVMe endpoint function driver mapping

### DIFF
--- a/drivers/pci/endpoint/functions/pci-epf-nvme.c
+++ b/drivers/pci/endpoint/functions/pci-epf-nvme.c
@@ -290,10 +290,13 @@ static int pci_epf_nvme_map(struct pci_epf_nvme *nvme,
 	size_t ofst;
 	int ret;
 
+	// Map size, round to the next power of two times 2
+	map->size = 1 << (fls64(size-1)+1);
 	map->pci_addr = pci_addr;
-	map->pci_base = ALIGN_DOWN(pci_addr, PAGE_SIZE);
+	map->pci_base = ALIGN_DOWN(pci_addr, map->size);
+	// Above is equivalent to: map->pci_base = pci_addr & ~(map->size-1);
 	ofst = map->pci_addr - map->pci_base;
-	map->size = ALIGN(size + ofst, PAGE_SIZE);
+	// Above is equivalent to: ofst = map->pci_addr & (map->size-1);
 
 	map->virt_base = pci_epc_mem_alloc_addr(epc, &map->phys_base, map->size);
 	if (!map->virt_base) {


### PR DESCRIPTION
Hello,
This should work, I checked the PCIe endpoint controller, still has the num_pass_bits computation as in my patch.
The code here is what I suggest on the NVMe side, from what I saw on your V18 is that you passed the "size" parameter and not the "map->size" parameter as in the V17

see V18 : https://github.com/damien-lemoal/linux/blob/rockpro64_ep_v18/drivers/pci/endpoint/functions/pci-epf-nvme.c#L315
versus V17 : https://github.com/rick-heig/linux/blob/rockpro64_ep_v17/drivers/pci/endpoint/functions/pci-epf-nvme.c#L308

I believe this is the reason why my solution didn't work, I wasn't expecting you to change that.

I hope it works !

Best regards,
Rick